### PR TITLE
Add Scaladoc and documentation workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,38 @@
+name: docs
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+      - uses: sbt/setup-sbt@v1
+      - run: sbt doc
+      - run: |
+          mkdir site
+          cp -r target/scala-*/api site/api
+          cp docs/index.html site/index.html
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v1

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>Nir4S Documentation</title>
+</head>
+<body>
+INDEX DEFINITION HERE
+</body>
+</html>

--- a/src/main/scala/nir/NIRGraph.scala
+++ b/src/main/scala/nir/NIRGraph.scala
@@ -2,6 +2,10 @@ package nir
 
 import java.io.File
 
+/** Directed graph composed of NIR nodes.
+  *
+  * @param nodes collection of nodes forming the graph
+  */
 case class NIRGraph(nodes: Set[NIRNode]) {
   val input: NIRNode = nodes.find(_.previous.size == 0).get
   val output: NIRNode = nodes.find(_.params.nirType == "Output")

--- a/src/main/scala/nir/NIRNode.scala
+++ b/src/main/scala/nir/NIRNode.scala
@@ -3,12 +3,25 @@ package nir
 
 import tensor._
 
+/** Unresolved graph node identified only by string IDs for its
+  * predecessors.
+  *
+  * @param id unique identifier for this node
+  * @param prevIds identifiers of predecessor nodes
+  * @param params operation parameters for this node
+  */
 case class RawNode(
   id:      String,
   prevIds: Set[String],
   params:  NIRParams
 )
 
+/** Resolved node within a NIR graph.
+  *
+  * @param id unique identifier for this node
+  * @param previous actual predecessor nodes
+  * @param params operation parameters associated with this node
+  */
 case class NIRNode(
   id:       String,
   previous: Set[NIRNode],
@@ -25,6 +38,16 @@ sealed trait NIRParams {
   def toString: String
 }
 
+/** Parameters describing a one-dimensional convolution operation.
+  *
+  * @param weight filter weights with shape `(out, in, k)`
+  * @param bias bias tensor
+  * @param stride stride along the spatial dimension
+  * @param padding zero-padding applied to the input
+  * @param dilation dilation factor of the kernel
+  * @param groups number of groups the input is split into
+  * @param input_shape length of the input signal
+  */
 final case class Conv1DParams(
   weight: TensorStatic[Float],
   bias: TensorStatic[Float],
@@ -50,6 +73,16 @@ final case class Conv1DParams(
   }
 }
 
+/** Parameters describing a two-dimensional convolution operation.
+  *
+  * @param weight filter weights `(out, in, kH, kW)`
+  * @param bias bias tensor
+  * @param stride strides along height and width
+  * @param padding padding along height and width
+  * @param dilation dilation factors
+  * @param groups grouping factor
+  * @param input_shape spatial dimensions of the input
+  */
 final case class Conv2DParams(
   weight: TensorStatic[Float],
   bias: TensorStatic[Float],
@@ -75,6 +108,12 @@ final case class Conv2DParams(
   }
 }
 
+/** Parameters for flattening a tensor into a lower rank.
+  *
+  * @param start_dim first dimension to flatten
+  * @param end_dim last dimension to flatten
+  * @param input_type original tensor shape
+  */
 final case class FlattenParams(
   start_dim: Long,
   end_dim: Long,
@@ -86,6 +125,12 @@ final case class FlattenParams(
   }
 }
 
+/** Parameters for two-dimensional sum pooling.
+  *
+  * @param kernel_size size of the pooling window
+  * @param padding padding applied before pooling
+  * @param stride step of the pooling window
+  */
 final case class SumPool2DParams(
   kernel_size: TensorStatic[Long],
   padding: TensorStatic[Long],
@@ -98,6 +143,12 @@ final case class SumPool2DParams(
 }
 
 
+/** Leaky integrator neuron parameters.
+  *
+  * @param tau time constant
+  * @param r resistance
+  * @param v_leak leak potential
+  */
 final case class LIParams(
   tau: TensorStatic[Float],
   r: TensorStatic[Float],
@@ -109,6 +160,12 @@ final case class LIParams(
   }
 }
 
+/** Integrate-and-fire neuron parameters.
+  *
+  * @param r membrane resistance
+  * @param v_reset reset potential
+  * @param v_threshold firing threshold
+  */
 final case class IFParams(
   r: TensorStatic[Float],
   v_reset: TensorStatic[Float],
@@ -120,6 +177,13 @@ final case class IFParams(
   }
 }
 
+/** Leaky integrate-and-fire neuron parameters.
+  *
+  * @param tau membrane time constant
+  * @param r membrane resistance
+  * @param v_leak leak potential
+  * @param v_threshold firing threshold
+  */
 final case class LIFParams(
   tau: TensorStatic[Float],
   r: TensorStatic[Float],
@@ -132,6 +196,12 @@ final case class LIFParams(
   }
 }
 
+/** Current-based LIF neuron parameters with excitatory and inhibitory time constants.
+  *
+  * @param tau membrane time constant
+  * @param tauSynExc excitatory synapse constant
+  * @param tauSynInh inhibitory synapse constant
+  */
 final case class CubaLIFParams(
   tau: TensorStatic[Float],
   tauSynExc: TensorStatic[Float],
@@ -143,6 +213,10 @@ final case class CubaLIFParams(
   }
 }
 
+/** Parameters of a linear transformation.
+  *
+  * @param weight transformation matrix
+  */
 final case class LinearParams(
   weight: TensorStatic[Float],
 ) extends NIRParams {
@@ -152,6 +226,11 @@ final case class LinearParams(
   }
 }
 
+/** Parameters of an affine transformation.
+  *
+  * @param bias bias vector
+  * @param weight weight matrix
+  */
 final case class AffineParams(
   bias: TensorStatic[Float],
   weight: TensorStatic[Float],
@@ -162,6 +241,10 @@ final case class AffineParams(
   }
 }
 
+/** Parameters describing the input node of a graph.
+  *
+  * @param shape shape of the incoming tensor
+  */
 final case class InputParams(
   shape: TensorStatic[Long],
 ) extends NIRParams {
@@ -171,6 +254,10 @@ final case class InputParams(
   }
 }
 
+/** Parameters describing the output node of a graph.
+  *
+  * @param shape shape of the produced tensor
+  */
 final case class OutputParams(
   shape: TensorStatic[Long],
 ) extends NIRParams {

--- a/src/main/scala/nir/tensor/Iso.scala
+++ b/src/main/scala/nir/tensor/Iso.scala
@@ -10,7 +10,19 @@ sealed trait Shape
 
 // Tree of indices for flat array.
 sealed trait RangeTree
+/** Leaf node representing the half-open interval \[begin, end) in the
+  * flattened tensor index space.
+  *
+  * @param begin starting index (inclusive)
+  * @param end ending index (exclusive)
+  */
 case class Leaf(begin: Int, end: Int) extends RangeTree
+
+/** Branch node composed of child ranges, used to model multidimensional
+  * tensor shapes.
+  *
+  * @param children nested range tree elements
+  */
 case class Branch(children: List[RangeTree]) extends RangeTree
 
 

--- a/src/main/scala/nir/tensor/TensorDynamic.scala
+++ b/src/main/scala/nir/tensor/TensorDynamic.scala
@@ -12,7 +12,14 @@ import scala.language.implicitConversions
  */
 
 
-// Indexer class to index 1D array in Tensor
+/** Utility to translate multidimensional tensor indices into a single
+  * row-major offset.
+  *
+  * For a tensor of shape `(2, 3)` the index `(1, 2)` is computed as
+  * \(1 \times 3 + 2 = 5\).
+  *
+  * @param shape dimensions of the tensor in each axis
+  */
 case class Indexer(shape: List[Int]) {
 
   def rank: Int = shape.length

--- a/src/main/scala/nir/tensor/TensorStatic.scala
+++ b/src/main/scala/nir/tensor/TensorStatic.scala
@@ -34,6 +34,12 @@ sealed trait TensorStatic[T] {
  class ShapeException(message: String) extends IllegalArgumentException(message)
 }
 
+/** One-dimensional tensor backed by an array.
+  *
+  * The number of elements equals the single dimension in `shape`.
+  * Example: `Tensor1D(Array(1,2,3), List(3))` represents the vector
+  * \(\mathbf{v} = (1,2,3)\).
+  */
 case class Tensor1D[T](data: Array[T], shape: List[Int]) extends TensorStatic[T] {
   // TODO: Somehow make this compile-safe, _without_ writing 500 lines of code.
   require(shape.length == 1)
@@ -65,6 +71,13 @@ object Tensor1D {
   }
 }
 
+/** Two-dimensional tensor stored as an array of rows.
+  *
+  * Its total size is given by \(\prod_i \text{shape}_i\).
+  *
+  * @param data nested 1D tensors representing rows
+  * @param shape dimensions of the tensor
+  */
 case class Tensor2D[T](data: Array[Tensor1D[T]], shape: List[Int]) extends TensorStatic[T] {
   override def rank: Int = 2
   override def length: Int = data.length
@@ -100,6 +113,11 @@ object Tensor2D {
 
 
 
+/** Three-dimensional tensor represented as an array of 2D slices.
+  *
+  * @param data slices composing this tensor
+  * @param shape dimensions of the tensor
+  */
 case class Tensor3D[T](data: Array[Tensor2D[T]], shape: List[Int]) extends TensorStatic[T] {
   override def rank: Int = 3
   override def length: Int = data.length


### PR DESCRIPTION
## Summary
- add Scaladoc comments to tensor and graph case classes
- seed docs/index.html placeholder for GitHub Pages
- set up GitHub Actions workflow to publish Scaladoc to Pages

## Testing
- `sbt doc` *(fails: command not found; package installation blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68c159346214832c8cd06a3353fa5eba